### PR TITLE
Remove smoke tests from publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,9 +20,4 @@ jobs:
       - uses: actions/checkout@v4
       - uses: astral-sh/setup-uv@v3
       - run: uv build
-      # Check that basic features work and we didn't miss to include crucial files
-      - name: Smoke test (wheel)
-        run: uv run --isolated --no-project -p 3.13 --with dist/*.whl tests/smoke_test.py
-      - name: Smoke test (source distribution)
-        run: uv run --isolated --no-project -p 3.13 --with dist/*.tar.gz tests/smoke_test.py
       - run: uv publish --trusted-publishing always


### PR DESCRIPTION
Removed smoke tests for wheel and source distribution from the publish workflow.